### PR TITLE
fix(ci): replace create-release action with GitHub CLI for automatic …

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -33,17 +33,12 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Create GitHub Release
-      id: create_release
-      uses: actions/create-release@v1
+      run: |
+        gh release create ${{ steps.bump_version.outputs.new_tag }} \
+          --title "Release ${{ steps.bump_version.outputs.new_tag }}" \
+          --generate-notes
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.bump_version.outputs.new_tag }}
-        release_name: Release ${{ steps.bump_version.outputs.new_tag }}
-        body: "" # Optional: Add custom body text here if needed
-        draft: false
-        prerelease: false
-        generate_release_notes: true # This enables automatic release note generation
 
     - name: Setup NPM Authentication
       run: |


### PR DESCRIPTION
…release notes

Resolves the `Unexpected input` error by switching from the deprecated actions/create-release@v1 to the GitHub CLI approach. This change ensures proper generation of release notes during the automated release process with the `--generate-notes` flag.