### PR TITLE
fix(generate): honor nullable on scalar columns (integer/float/boolean/enum/etc.)

### DIFF
--- a/src/lib/templates/entities/entity-col-bigint.eta
+++ b/src/lib/templates/entities/entity-col-bigint.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "bigint"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "bigint", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-boolean.eta
+++ b/src/lib/templates/entities/entity-col-boolean.eta
@@ -3,7 +3,7 @@
 @IsOptional({ groups: [CREATE, UPDATE] })
 @IsBoolean({ always: true })
 
-@Column({ type: 'boolean', default: <%= Boolean(field.default) || false %> })
+@Column({ type: 'boolean', nullable: <%= Boolean(field.nullable) %>, default: <%= Boolean(field.default) || false %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-bytea.eta
+++ b/src/lib/templates/entities/entity-col-bytea.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "bytea"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "bytea", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-decimal.eta
+++ b/src/lib/templates/entities/entity-col-decimal.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "decimal", precision: <%= field.precision || 10 %>, scale: <%= field.scale || 2 %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "decimal", nullable: <%= Boolean(field.nullable) %>, precision: <%= field.precision || 10 %>, scale: <%= field.scale || 2 %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-double.eta
+++ b/src/lib/templates/entities/entity-col-double.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "float8"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "float8", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-enum.eta
+++ b/src/lib/templates/entities/entity-col-enum.eta
@@ -2,6 +2,7 @@
 
 @Column({
     type: 'enum',
+    nullable: <%= Boolean(field.nullable) %>,
     enum: enums.<%= field.dataType%>,
     default: enums.<%= field.dataType%>.<%= field.default.toLowerCase().replace(/[^a-z0-9]/g, '_').replace(/^(\d)/, '_$1').replace(/_+/g, '_').replace(/_$/, '') %>
 })

--- a/src/lib/templates/entities/entity-col-float.eta
+++ b/src/lib/templates/entities/entity-col-float.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "decimal"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "decimal", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-integer.eta
+++ b/src/lib/templates/entities/entity-col-integer.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "int"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "int", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-interval.eta
+++ b/src/lib/templates/entities/entity-col-interval.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "interval"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "interval", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-money.eta
+++ b/src/lib/templates/entities/entity-col-money.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "money"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "money", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-numeric.eta
+++ b/src/lib/templates/entities/entity-col-numeric.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "numeric", precision: <%= field.precision || 10 %>, scale: <%= field.scale || 2 %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "numeric", nullable: <%= Boolean(field.nullable) %>, precision: <%= field.precision || 10 %>, scale: <%= field.scale || 2 %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-real.eta
+++ b/src/lib/templates/entities/entity-col-real.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "real"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "real", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-smallint.eta
+++ b/src/lib/templates/entities/entity-col-smallint.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "smallint"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "smallint", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-time.eta
+++ b/src/lib/templates/entities/entity-col-time.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "time"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "time", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-timetz.eta
+++ b/src/lib/templates/entities/entity-col-timetz.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "timetz"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "timetz", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-uuid.eta
+++ b/src/lib/templates/entities/entity-col-uuid.eta
@@ -3,7 +3,7 @@
 <% if (field.primary ) {%>
 @PrimaryGeneratedColumn('uuid')
 <% } else { %>
-@Column({ "type": "uuid"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "uuid", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>


### PR DESCRIPTION
## Problem

`apso generate` drops `nullable: true` on **scalar** column types, so a field declared `"nullable": true` in `.apsorc` is emitted as a `NOT NULL` TypeORM column. Inserting `null` then fails at runtime:

```
null value in column "..." violates not-null constraint
```

The `text`, `json`, `date`, `timestamp`, etc. templates already emit `nullable: <%= Boolean(field.nullable) %>`, but the numeric family and several others did not.

Fixes #61.

## Fix

Add `nullable: <%= Boolean(field.nullable) %>` to the affected `entities/entity-col-*.eta` templates, mirroring the text/json templates:

`integer, bigint, smallint, decimal, numeric, float, double, real, money, boolean, enum, time, timetz, interval, bytea, uuid (non-PK)`

Auto-increment `serial`/`bigserial`/`smallserial` and uuid **primary keys** are intentionally left unchanged (nullability is meaningless there).

## Before / after (integer)

```diff
-@Column({ "type": "int"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "int", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
```

A nullable field now generates `@Column({ "type": "int", nullable: true, default: 1 })`; a non-nullable field generates `nullable: false` (unchanged behavior).

## Verified

Regenerated a service with a `{ "type": "integer", "nullable": true }` field against this change and confirmed the column is created nullable and accepts `null` inserts; non-nullable fields are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)