### PR TITLE
test: update stale Go generator assertions after template fixes

### DIFF
--- a/test/lib/generators/go.test.ts
+++ b/test/lib/generators/go.test.ts
@@ -49,7 +49,8 @@ describe("GoGenerator", () => {
       expect(content).toBeDefined();
       expect(content).toContain("package models");
       expect(content).toContain(`"time"`);
-      expect(content).toContain(`"gorm.io/gorm"`);
+      // gorm.io/gorm is no longer imported (unused imports are Go compile errors)
+      expect(content).not.toContain(`"gorm.io/gorm"`);
       expect(content).toContain("type User struct {");
     });
 
@@ -291,7 +292,7 @@ describe("GoGenerator", () => {
       });
 
       const content = findFileContent(files, "order.go")!;
-      expect(content).toContain(`"app/models/enums"`);
+      expect(content).toContain(`"app/autogen/models/enums"`);
     });
   });
 


### PR DESCRIPTION
## Summary

CI on `main` is currently red: two `GoGenerator` tests fail on every PR (this is what's failing the `build-and-publish` check on #62 and #63).

Commit `eaae7b1` (query utilities) intentionally fixed pre-existing Go template bugs — it removed the unused `gorm.io/gorm` import (unused imports are compile errors in Go) and corrected the enums import path from `app/models/enums` to `app/autogen/models/enums` — but the two test assertions in `test/lib/generators/go.test.ts` were never updated to match.

## Changes

- `generates GORM struct with correct package and imports`: now asserts `gorm.io/gorm` is **not** imported
- `enum field imports enums package`: expects `app/autogen/models/enums`

Full suite after this change: 17 suites, 179 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)