### PR TITLE
feat: warn when a newer @apso/cli version is available

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14,6 +14,7 @@
         "@oclif/core": "^2",
         "@oclif/plugin-help": "^5",
         "@oclif/plugin-plugins": "^3",
+        "@oclif/plugin-warn-if-update-available": "^2.1.1",
         "debug": "^4.3.4",
         "eta": "^2.0.0",
         "inquirer": "^8.2.7",
@@ -1752,9 +1753,10 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "2.11.10",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.11.10.tgz",
-      "integrity": "sha512-/7Umij3OU++6o+z4U+waJ5nP6IvK9KKEVzz+xsla68YoECLQwz43boUKqYizlNMtTfiwNkiYb5QE+OU/q5qEtA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.16.0.tgz",
+      "integrity": "sha512-dL6atBH0zCZl1A1IXCKJgLPrM/wR7K+Wi401E/IvqsK8m2iCHW+0TEOGrans/cuN3oTW+uxIyJFHJ8Im0k4qBw==",
+      "license": "MIT",
       "dependencies": {
         "@types/cli-progress": "^3.11.0",
         "ansi-escapes": "^4.3.2",
@@ -1765,7 +1767,6 @@
         "cli-progress": "^3.12.0",
         "debug": "^4.3.4",
         "ejs": "^3.1.8",
-        "fs-extra": "^9.1.0",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
         "hyperlinker": "^1.0.0",
@@ -1775,7 +1776,6 @@
         "natural-orderby": "^2.0.3",
         "object-treeify": "^1.1.33",
         "password-prompt": "^1.1.2",
-        "semver": "^7.5.3",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
@@ -1841,18 +1841,17 @@
       }
     },
     "node_modules/@oclif/plugin-warn-if-update-available": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-2.0.37.tgz",
-      "integrity": "sha512-rfDNvplwgiwV+QSV4JU96ypmWgNJ6Hk5FEAEAKzqF0v0J8AHwZGpwwYO/MCZSkbc7bfYpkqLx/sxjpMO6j6PmQ==",
-      "dev": true,
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-2.1.1.tgz",
+      "integrity": "sha512-y7eSzT6R5bmTIJbiMMXgOlbBpcWXGlVhNeQJBLBCCy1+90Wbjyqf6uvY0i2WcO4sh/THTJ20qCW80j3XUlgDTA==",
+      "license": "MIT",
       "dependencies": {
-        "@oclif/core": "^2.8.2",
+        "@oclif/core": "^2.15.0",
         "chalk": "^4.1.0",
         "debug": "^4.1.0",
-        "fs-extra": "^9.0.1",
         "http-call": "^5.2.2",
-        "lodash": "^4.17.21",
-        "semver": "^7.5.1"
+        "lodash.template": "^4.5.0",
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -8334,6 +8333,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8345,6 +8350,26 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.template": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.18.1.tgz",
+      "integrity": "sha512-5urZrLnV/VD6zHK5KsVtZgt7H19v51mIzoS0aBNH8yp3I8tbswrEjOABOPY8m8uB7NuibubLrMX+Y0PXsU9X+w==",
+      "deprecated": "This package is deprecated. Use https://socket.dev/npm/package/eta instead.",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "node_modules/lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@oclif/core": "^2",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^3",
+    "@oclif/plugin-warn-if-update-available": "^2.1.1",
     "debug": "^4.3.4",
     "eta": "^2.0.0",
     "inquirer": "^8.2.7",
@@ -74,8 +75,14 @@
     "commands": "./dist/commands",
     "plugins": [
       "@oclif/plugin-help",
-      "@oclif/plugin-plugins"
+      "@oclif/plugin-plugins",
+      "@oclif/plugin-warn-if-update-available"
     ],
+    "warn-if-update-available": {
+      "timeoutInDays": 1,
+      "registry": "https://registry.npmjs.org",
+      "message": "<%= config.name %> update available: <%= chalk.dim(config.version) %> → <%= chalk.greenBright(latest) %>. Run <%= chalk.cyan('npm i -g @apso/cli') %> to update."
+    },
     "topicSeparator": " ",
     "topics": {
       "server": {


### PR DESCRIPTION
## Summary

Adds `@oclif/plugin-warn-if-update-available` so the CLI tells users when they're running an outdated version. There was previously no update mechanism at all — no `update` command, no update plugins, and `apso doctor` didn't check the installed version against the registry. (Notably, #61 was reported against 0.12.0 while we were publishing 0.15.x.)

## What it does

On every command, an `init` hook reads a cached copy of the latest npm dist-tags and prints a warning if a newer version exists:

```
 ›   Warning: @apso/cli update available: 0.15.1 → 99.0.0. Run npm i -g @apso/cli to update.
```

The registry check runs in a **detached background process** and is **throttled to once per day** (`timeoutInDays: 1`), so it never blocks or slows down commands. No warning is shown when up to date, on prerelease versions, or while running `update`.

## Config (package.json `oclif` block)

- plugin added to `plugins`
- `warn-if-update-available`: daily check against `https://registry.npmjs.org`, custom message pointing at `npm i -g @apso/cli`

## Why not a self-updating `apso update` command?

`@oclif/plugin-update` targets oclif's **tarball/standalone-binary** distribution (it pulls new tarballs from a channel), not npm installs. For an npm-installed CLI an `apso update` command would just wrap `npm i -g`, which has PATH/permissions pitfalls. The right time to add it is alongside the Homebrew/binary distribution already in the backlog.

## Verification

- `npm run build`: clean
- `apso --version` / `--help`: load correctly with the plugin
- Seeded the version cache with a higher `latest` → warning printed; with an equal version → silent (both verified manually)
- npm bumped `@oclif/core` 2.11.x → 2.16.0 to satisfy the plugin peer dep, within the existing `^2` range

> Note: this branch is off `main`, which currently has no passing CI re-run mechanism for PR pushes — see the separate note about `unitTests.yml` only triggering on `opened/reopened`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)