### PR TITLE
fix: preserve nullable on remaining scalar column types (boolean/enum/uuid/etc.)

### DIFF
--- a/src/lib/templates/entities/entity-col-boolean.eta
+++ b/src/lib/templates/entities/entity-col-boolean.eta
@@ -3,7 +3,7 @@
 @IsOptional({ groups: [CREATE, UPDATE] })
 @IsBoolean({ always: true })
 
-@Column({ type: 'boolean', default: <%= Boolean(field.default) || false %> })
+@Column({ type: 'boolean', nullable: <%= Boolean(field.nullable) %>, default: <%= Boolean(field.default) || false %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-bytea.eta
+++ b/src/lib/templates/entities/entity-col-bytea.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "bytea"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "bytea", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-enum.eta
+++ b/src/lib/templates/entities/entity-col-enum.eta
@@ -2,6 +2,7 @@
 
 @Column({
     type: 'enum',
+    nullable: <%= Boolean(field.nullable) %>,
     enum: enums.<%= field.dataType%>,
     default: enums.<%= field.dataType%>.<%= field.default.toLowerCase().replace(/[^a-z0-9]/g, '_').replace(/^(\d)/, '_$1').replace(/_+/g, '_').replace(/_$/, '') %>
 })

--- a/src/lib/templates/entities/entity-col-interval.eta
+++ b/src/lib/templates/entities/entity-col-interval.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "interval"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "interval", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-time.eta
+++ b/src/lib/templates/entities/entity-col-time.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "time"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "time", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-timetz.eta
+++ b/src/lib/templates/entities/entity-col-timetz.eta
@@ -1,6 +1,6 @@
 <% const {field} = it; %>
 
-@Column({ "type": "timetz"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "timetz", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/src/lib/templates/entities/entity-col-uuid.eta
+++ b/src/lib/templates/entities/entity-col-uuid.eta
@@ -3,7 +3,7 @@
 <% if (field.primary ) {%>
 @PrimaryGeneratedColumn('uuid')
 <% } else { %>
-@Column({ "type": "uuid"<% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
+@Column({ "type": "uuid", nullable: <%= Boolean(field.nullable) %><% if (field.default !== null) {%>, default:  <%= field.default %><% } %> })
 <% if (field.index ) {%>
 @Index()
 <% } %>

--- a/test/lib/generators/typescript.test.ts
+++ b/test/lib/generators/typescript.test.ts
@@ -193,5 +193,38 @@ describe("TypeScriptGenerator", () => {
       expect(entityContent).toContain('@Column({ "type": "real", nullable: true })');
       expect(entityContent).toContain('@Column({ "type": "money", nullable: true })');
     });
+
+    test("nullable boolean, enum, and other scalar types keep nullable: true", async () => {
+      const entity: Entity = {
+        name: "Profile",
+        primaryKeyType: "serial",
+        fields: [
+          { name: "active", type: "boolean", nullable: true },
+          { name: "tier", type: "enum", nullable: true, values: ["free", "pro"] },
+          { name: "avatar", type: "bytea", nullable: true },
+          { name: "sessionLength", type: "interval", nullable: true },
+          { name: "checkIn", type: "time", nullable: true },
+          { name: "checkOut", type: "timetz", nullable: true },
+          { name: "externalId", type: "uuid", nullable: true },
+        ] as unknown as Field[],
+      };
+
+      const files = await generator.generateEntity({
+        entity,
+        relationships: [],
+        allEntities: [entity],
+        apiType: "rest",
+      });
+
+      const entityContent = findFileContent(files, "Profile.entity");
+      expect(entityContent).toBeDefined();
+      expect(entityContent).toContain("type: 'boolean', nullable: true");
+      expect(entityContent).toContain("nullable: true,\n    enum:");
+      expect(entityContent).toContain('@Column({ "type": "bytea", nullable: true })');
+      expect(entityContent).toContain('@Column({ "type": "interval", nullable: true })');
+      expect(entityContent).toContain('@Column({ "type": "time", nullable: true })');
+      expect(entityContent).toContain('@Column({ "type": "timetz", nullable: true })');
+      expect(entityContent).toContain('@Column({ "type": "uuid", nullable: true })');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Completes the nullable fix from #61. PR #63 (merged) fixed the **numeric** column templates. This adds the same one-line fix to the remaining scalar types whose templates also omitted `nullable`: `boolean`, `enum`, `bytea`, `interval`, `time`, `timetz`, `uuid`.

## Background — why this is a separate PR

These seven template fixes originally lived in #62. During review #62 was closed as "superseded by #63" after I ported its changes onto the #63 branch — but #63 was merged at an earlier commit, so the ported commit never landed in `main`, and #62 was already closed. This PR restores that lost work (cherry-picked from the original commit) so the remaining types aren't left broken.

```ts
// boolean, before / after
@Column({ type: 'boolean', default: ... })
@Column({ type: 'boolean', nullable: true, default: ... })
```

## Tests

Adds a regression test in `test/lib/generators/typescript.test.ts` covering nullable `boolean`, `enum`, `bytea`, `interval`, `time`, `timetz`, and `uuid`.

`npm run test` (jest + posttest lint): **17 suites, 184 tests, 0 lint errors, exit 0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)