### PR TITLE
ci: re-run unit tests when commits are pushed to a PR

### DIFF
--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -2,7 +2,7 @@ name: run unit tests
 
 on:
     pull_request:
-        types: [opened, reopened]
+        types: [opened, reopened, synchronize]
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
## Summary

`unitTests.yml` triggered only on `pull_request` `opened`/`reopened`, so new commits pushed to an open PR never re-ran the suite — the `build-and-publish` check reflected only the PR's first commit. This is why #63's check stayed red on its original commit even after the fixes that made it pass were pushed.

Adds the `synchronize` activity type so every push to a PR re-runs the checks.

```diff
 on:
     pull_request:
-        types: [opened, reopened]
+        types: [opened, reopened, synchronize]
```

## Note

This PR is itself the first validation: it should get one run on open. Once merged, subsequent pushes to any open PR will re-trigger CI as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)