### PR TITLE
fix: pass report_issue title via argv, not a shell string (security, #73)

### DIFF
--- a/src/commands/mcp/serve.ts
+++ b/src/commands/mcp/serve.ts
@@ -20,6 +20,7 @@ import {
   formatFindings,
   isGhAvailable,
   searchExistingIssues,
+  fileIssue,
 } from "../../lib/doctor/runner";
 import { createFile } from "../../lib/utils/file-system";
 import { apsorcToServiceSchema } from "../../lib/utils/schema-convert";
@@ -872,16 +873,11 @@ export default class McpServe extends BaseCommand {
             };
           }
 
-          // File the issue
-          const { execSync } = await import("child_process");
-          const url = execSync(
-            `gh issue create --repo apsoai/cli --title "${title.replace(/"/g, '\\"')}" --body-file -`,
-            {
-              input: body,
-              encoding: "utf-8",
-              timeout: 30_000,
-            }
-          ).trim();
+          // File the issue. fileIssue passes the title as a discrete argv
+          // element and the body via a temp file (execFile, shell: false), so
+          // backticks / $() / quotes in user-supplied content are never
+          // shell-evaluated (no command injection).
+          const url = fileIssue(title, body);
 
           return {
             content: [

--- a/src/lib/doctor/runner.ts
+++ b/src/lib/doctor/runner.ts
@@ -1,5 +1,7 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
+import * as fs from "fs";
 import * as os from "os";
+import * as path from "path";
 import { DiagnosticFinding, DiagnosticContext } from "./types";
 import {
   checkPkStrategy,
@@ -89,11 +91,43 @@ function formatFinding(f: DiagnosticFinding): string {
  */
 export function isGhAvailable(): boolean {
   try {
-    execSync("gh auth status", { stdio: "ignore" });
+    // execFile (shell: false) — no shell interpretation of arguments.
+    execFileSync("gh", ["auth", "status"], { stdio: "ignore" });
     return true;
   } catch {
     return false;
   }
+}
+
+/**
+ * The GitHub repository issues are filed against.
+ */
+const ISSUE_REPO = "apsoai/cli";
+
+/**
+ * Build the argv array for `gh issue list --search`.
+ *
+ * Pure function (no side effects) so it can be unit-tested. The search query
+ * is returned as its own array element and is NEVER concatenated into a shell
+ * string, so backticks / quotes / `$()` in the title are treated literally.
+ */
+export function buildIssueSearchArgs(title: string): string[] {
+  // Extract key terms from the title for search (passed as a single argv arg).
+  const searchQuery = title.slice(0, 100);
+  return [
+    "issue",
+    "list",
+    "--repo",
+    ISSUE_REPO,
+    "--search",
+    searchQuery,
+    "--state",
+    "open",
+    "--json",
+    "number,title,url",
+    "--limit",
+    "5",
+  ];
 }
 
 /**
@@ -103,15 +137,72 @@ export function searchExistingIssues(
   title: string
 ): { number: number; title: string; url: string }[] {
   try {
-    // Extract key terms from the title for search
-    const searchQuery = title.slice(0, 100);
-    const result = execSync(
-      `gh issue list --repo apsoai/cli --search "${searchQuery.replace(/"/g, '\\"')}" --state open --json number,title,url --limit 5`,
-      { encoding: "utf-8", timeout: 15_000 }
-    );
+    // execFile with an args array (shell: false). The title is passed as a
+    // distinct argv element, so it is never shell-evaluated.
+    const result = execFileSync("gh", buildIssueSearchArgs(title), {
+      encoding: "utf-8",
+      timeout: 15_000,
+    });
     return JSON.parse(result);
   } catch {
     return [];
+  }
+}
+
+/**
+ * Build the argv array for `gh issue create`.
+ *
+ * Pure function (no side effects) so it can be unit-tested. The title is
+ * returned as its own array element directly after `--title` and the body is
+ * passed via `--body-file <path>`. Nothing is concatenated into a shell string,
+ * so backticks / `$()` / quotes / newlines in the title are passed literally
+ * (no command substitution, no injection).
+ */
+export function buildIssueCreateArgs(
+  title: string,
+  bodyFilePath: string
+): string[] {
+  return [
+    "issue",
+    "create",
+    "--repo",
+    ISSUE_REPO,
+    "--title",
+    title,
+    "--body-file",
+    bodyFilePath,
+  ];
+}
+
+/**
+ * File a GitHub issue with an arbitrary title and body.
+ *
+ * The body is written to a temp file and passed via `--body-file`, and the
+ * title is passed as a discrete argv element via execFile (shell: false). The
+ * child's stdin is explicitly not inherited from the parent so it cannot
+ * consume / blank the body.
+ *
+ * Returns the URL of the created issue.
+ */
+export function fileIssue(title: string, body: string): string {
+  const bodyFilePath = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "apso-issue-")),
+    "body.md"
+  );
+  try {
+    fs.writeFileSync(bodyFilePath, body, "utf-8");
+
+    const result = execFileSync("gh", buildIssueCreateArgs(title, bodyFilePath), {
+      encoding: "utf-8",
+      timeout: 30_000,
+      // Do not pipe the parent's stdin into the child (the body is supplied via
+      // file). stdout/stderr are captured by execFileSync.
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    return result.trim();
+  } finally {
+    fs.rmSync(path.dirname(bodyFilePath), { recursive: true, force: true });
   }
 }
 
@@ -127,16 +218,7 @@ export function fileGitHubIssue(
   const title = buildIssueTitle(findings);
   const body = buildIssueBody(findings, ctx, pkg);
 
-  const result = execSync(
-    `gh issue create --repo apsoai/cli --title "${title.replace(/"/g, '\\"')}" --body-file -`,
-    {
-      input: body,
-      encoding: "utf-8",
-      timeout: 30_000,
-    }
-  );
-
-  return result.trim();
+  return fileIssue(title, body);
 }
 
 function loadCliVersion(): string {

--- a/test/lib/doctor/runner.test.ts
+++ b/test/lib/doctor/runner.test.ts
@@ -3,7 +3,12 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import { DiagnosticContext } from "../../../src/lib/doctor/types";
-import { runDiagnostics, formatFindings } from "../../../src/lib/doctor/runner";
+import {
+  runDiagnostics,
+  formatFindings,
+  buildIssueCreateArgs,
+  buildIssueSearchArgs,
+} from "../../../src/lib/doctor/runner";
 
 // Mock the migration sandbox to avoid PGlite dependency in unit tests
 jest.mock("../../../src/lib/migrate/sandbox", () => ({
@@ -169,5 +174,62 @@ describe("formatFindings", () => {
     expect(output).toContain("[WARNING] Unused import");
     expect(output).toContain("File: src/autogen/order/Order.entity.ts");
     expect(output).toContain("Fix: Fix it");
+  });
+});
+
+// Security regression: the issue TITLE must be passed to `gh` as a discrete
+// argv element (execFile / shell: false), NEVER interpolated into a shell
+// command string. A title containing backticks / $() / quotes must therefore
+// survive verbatim and must NOT be shell-evaluated (no command injection).
+describe("buildIssueCreateArgs (shell-injection safety)", () => {
+  test("passes the title verbatim as a single argv element", () => {
+    const title = "test `whoami` injection";
+    const args = buildIssueCreateArgs(title, "/tmp/body.md");
+
+    // The exact, untouched title appears as its own element.
+    expect(args).toContain(title);
+
+    // It sits immediately after the --title flag.
+    const titleIdx = args.indexOf("--title");
+    expect(titleIdx).toBeGreaterThanOrEqual(0);
+    expect(args[titleIdx + 1]).toBe(title);
+
+    // The body is supplied via a file path, not inline / stdin.
+    const bodyFileIdx = args.indexOf("--body-file");
+    expect(bodyFileIdx).toBeGreaterThanOrEqual(0);
+    expect(args[bodyFileIdx + 1]).toBe("/tmp/body.md");
+  });
+
+  test("backticks are preserved exactly (not substituted) and no element is a shell concatenation", () => {
+    const title = "bug: `rm -rf /` and $(curl evil.sh) \"quoted\"";
+    const args = buildIssueCreateArgs(title, "/tmp/body.md");
+
+    // Backtick / $() / quote characters are present, untouched, in the single
+    // title element — meaning a shell never had a chance to interpret them.
+    const titleArg = args[args.indexOf("--title") + 1];
+    expect(titleArg).toBe(title);
+    expect(titleArg).toContain("`rm -rf /`");
+    expect(titleArg).toContain("$(curl evil.sh)");
+
+    // No argv element is a single shell-command string that concatenates the
+    // title (which would be the bug). The dangerous payload only ever appears
+    // as the standalone, properly-separated title element.
+    const offending = args.filter(
+      (a) => a !== title && (a.includes("gh issue create") || a.includes("--title "))
+    );
+    expect(offending).toHaveLength(0);
+  });
+});
+
+describe("buildIssueSearchArgs (shell-injection safety)", () => {
+  test("passes the search query verbatim as a single argv element", () => {
+    const title = "test `whoami` injection";
+    const args = buildIssueSearchArgs(title);
+
+    const searchIdx = args.indexOf("--search");
+    expect(searchIdx).toBeGreaterThanOrEqual(0);
+    // Search uses the first 100 chars of the title, passed as one argv element.
+    expect(args[searchIdx + 1]).toBe(title.slice(0, 100));
+    expect(args[searchIdx + 1]).toContain("`whoami`");
   });
 });


### PR DESCRIPTION
Closes #73

## Problem
The `report_issue` MCP tool and the `apso doctor` issue-filing path built the `gh issue create` command as a **shell string** via `execSync`, interpolating the issue title. A title containing a markdown code-span (backticks) — normal in a CLI bug report — had its backtick-wrapped text **executed as a shell command** (`$()` too), with stdout injected into the title. This is arbitrary command execution from title content, and it also silently corrupted ordinary reports (and could blank the body when the spawned command consumed stdin).

## Fix
Switched the entire filing path from `execSync(commandString)` (shell) to `execFileSync("gh", argsArray)` (`shell: false` — no shell, no interpolation):
- Pure argv builders `buildIssueCreateArgs(title, bodyFilePath)` / `buildIssueSearchArgs(title)` — the title is a discrete argv element, never concatenated.
- Body written to a temp file and passed via `--body-file`; child stdin not inherited, so it can't consume/blank the body.
- Updated `report_issue` (serve.ts), `fileGitHubIssue`, `searchExistingIssues`, and `isGhAvailable`.

## Tests
Regression tests assert a title containing `` `whoami` ``, `` `rm -rf /` ``, `$(...)`, and quotes appears verbatim as the single argv element after `--title`/`--search`, and that no argv element is a shell string concatenating the title.

Build ✅ · lint 0 errors ✅ · `jest test/lib/doctor/runner.test.ts` (7) + `test/commands/server` (22) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)