### PR TITLE
fix: don't crash generating nullable enum with null/absent default (#72)

### DIFF
--- a/src/lib/templates/entities/entity-col-enum.eta
+++ b/src/lib/templates/entities/entity-col-enum.eta
@@ -3,8 +3,8 @@
 @Column({
     type: 'enum',
     nullable: <%= Boolean(field.nullable) %>,
-    enum: enums.<%= field.dataType%>,
-    default: enums.<%= field.dataType%>.<%= field.default.toLowerCase().replace(/[^a-z0-9]/g, '_').replace(/^(\d)/, '_$1').replace(/_+/g, '_').replace(/_$/, '') %>
+    enum: enums.<%= field.dataType%><% if (field.default !== null) { %>,
+    default: enums.<%= field.dataType%>.<%= field.default.toLowerCase().replace(/[^a-z0-9]/g, '_').replace(/^(\d)/, '_$1').replace(/_+/g, '_').replace(/_$/, '') %><% } %>
 })
 <% if (field.index ) {%>
 @Index()

--- a/test/lib/generators/typescript.test.ts
+++ b/test/lib/generators/typescript.test.ts
@@ -226,5 +226,33 @@ describe("TypeScriptGenerator", () => {
       expect(entityContent).toContain('@Column({ "type": "timetz", nullable: true })');
       expect(entityContent).toContain('@Column({ "type": "uuid", nullable: true })');
     });
+
+    test("nullable enum with explicit null default omits the default option", async () => {
+      const entity: Entity = {
+        name: "Foo",
+        primaryKeyType: "serial",
+        fields: [
+          { name: "tier", type: "enum", values: ["free", "pro"], nullable: true, default: null },
+        ] as unknown as Field[],
+      };
+
+      let files: { path: string; content: string }[] | undefined;
+      await expect(
+        (async () => {
+          files = await generator.generateEntity({
+            entity,
+            relationships: [],
+            allEntities: [entity],
+            apiType: "rest",
+          });
+        })()
+      ).resolves.not.toThrow();
+
+      const entityContent = findFileContent(files!, "Foo.entity");
+      expect(entityContent).toBeDefined();
+      expect(entityContent).toContain("nullable: true");
+      expect(entityContent).toContain("enum: enums.FooTierEnum");
+      expect(entityContent).not.toContain("default:");
+    });
   });
 });


### PR DESCRIPTION
Closes #72

## Problem
Generating an entity with a nullable enum that has no (or explicitly null) default threw `TypeError: Cannot read properties of null (reading 'toLowerCase')`. `getDefaultValueForField` returns `null` for that case, but `entity-col-enum.eta` always emitted a `default:` line and called `field.default.toLowerCase()` unconditionally.

## Fix
Guarded the `default:` option in `entity-col-enum.eta` with `<% if (field.default !== null) { %> ... <% } %>` (comma moved inside the guard), mirroring the numeric templates. A nullable enum with no default now generates:

```ts
@Column({ type: 'enum', nullable: true, enum: enums.FooTierEnum })
tier!: enums.FooTierEnum;
```

When a default is present, output is unchanged.

## Tests
Added a regression case (nullable enum, `default: null`) asserting generation does not throw, the `@Column` has `nullable: true` and `enum: enums.<...>`, and contains no `default:`.

Build ✅ · lint 0 errors ✅ · `jest test/lib/generators/typescript.test.ts` (9) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)