### PR TITLE
feat: add timestamptz / timestamp / datetime field types (#74)

### DIFF
--- a/src/commands/mcp/serve.ts
+++ b/src/commands/mcp/serve.ts
@@ -1010,8 +1010,8 @@ function validateSchemaObject(schema: Record<string, unknown>): string[] {
 
   const validFieldTypes = [
     "text", "string", "varchar", "integer", "float", "decimal", "numeric",
-    "boolean", "date", "timestamp", "datetime", "uuid", "enum", "json",
-    "json-plain", "array",
+    "boolean", "date", "timestamptz", "timestamp", "datetime", "uuid", "enum",
+    "json", "json-plain", "array",
   ];
   const validRelTypes = ["OneToMany", "ManyToOne", "ManyToMany", "OneToOne"];
   const entityNames = new Set<string>();

--- a/src/lib/doctor/checks.ts
+++ b/src/lib/doctor/checks.ts
@@ -156,7 +156,7 @@ export function checkFieldTypeMismatch(ctx: DiagnosticContext): DiagnosticFindin
           severity: "error",
           message: `Entity "${entity.name}", field "${field.name}": type "${field.type}" is not recognized by the generator`,
           entity: entity.name,
-          suggestion: `Valid types: text, integer, float, decimal, numeric, boolean, date, enum, json, json-plain, array, uuid`,
+          suggestion: `Valid types: text, integer, float, decimal, numeric, boolean, date, timestamptz, timestamp, datetime, enum, json, json-plain, array, uuid`,
         });
       }
 

--- a/src/lib/types/field.ts
+++ b/src/lib/types/field.ts
@@ -8,6 +8,9 @@ export type FieldType =
   | "decimal"
   | "numeric"
   | "date"
+  | "timestamptz"
+  | "timestamp"
+  | "datetime"
   | "json"
   | "json-plain";
 

--- a/src/lib/utils/field.ts
+++ b/src/lib/utils/field.ts
@@ -27,6 +27,7 @@ export const fieldTypeToColumnType: Record<string, string> = {
   date: "date",
   timestamp: "timestamp",
   timestamptz: "timestamptz",
+  datetime: "timestamp",
   time: "time",
   timetz: "timetz",
   json: "json",
@@ -66,6 +67,8 @@ const fieldTypeNormalizationMap: Record<string, string> = {
   "time with time zone": "timetz",
   "timestamp without time zone": "timestamp",
   "timestamp with time zone": "timestamptz",
+  // `datetime` is a user-facing alias for a naive timestamp (instant-in-time).
+  datetime: "timestamp",
 };
 
 /**
@@ -103,6 +106,7 @@ const typeToJsType: Record<string, string> = {
   date: "string",
   timestamp: "string",
   timestamptz: "string",
+  datetime: "string",
   timetz: "string",
   tsvector: "string",
   string: "string",

--- a/test/lib/doctor/checks.test.ts
+++ b/test/lib/doctor/checks.test.ts
@@ -290,6 +290,24 @@ describe("checkFieldTypeMismatch", () => {
     expect(findings).toHaveLength(0);
   });
 
+  test("instant-in-time types (timestamptz, timestamp, datetime) pass", () => {
+    const ctx = baseCtx("", {
+      entities: [
+        {
+          name: "Event",
+          fields: [
+            { name: "capturedAt", type: "timestamptz", nullable: true },
+            { name: "occurredAt", type: "timestamp", nullable: false },
+            { name: "loggedAt", type: "datetime", nullable: true },
+          ],
+        },
+      ],
+    });
+
+    const findings = checkFieldTypeMismatch(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
   test("unknown type errors", () => {
     const ctx = baseCtx("", {
       entities: [

--- a/test/lib/generators/typescript.test.ts
+++ b/test/lib/generators/typescript.test.ts
@@ -226,5 +226,42 @@ describe("TypeScriptGenerator", () => {
       expect(entityContent).toContain('@Column({ "type": "timetz", nullable: true })');
       expect(entityContent).toContain('@Column({ "type": "uuid", nullable: true })');
     });
+
+    test("timestamptz, timestamp, and datetime generate instant-in-time columns honoring nullable", async () => {
+      const entity: Entity = {
+        name: "Event",
+        primaryKeyType: "serial",
+        fields: [
+          { name: "capturedAt", type: "timestamptz", nullable: true },
+          { name: "occurredAt", type: "timestamp", nullable: false },
+          { name: "loggedAt", type: "datetime", nullable: true },
+        ] as unknown as Field[],
+      };
+
+      const files = await generator.generateEntity({
+        entity,
+        relationships: [],
+        allEntities: [entity],
+        apiType: "rest",
+      });
+
+      const entityContent = findFileContent(files, "Event.entity");
+      expect(entityContent).toBeDefined();
+      // timestamptz (tz-aware) keeps its own column type
+      expect(entityContent).toContain(
+        "@Column({ type: 'timestamptz', nullable: true })"
+      );
+      expect(entityContent).toContain("capturedAt: Date;");
+      // timestamp (naive) honors nullable: false
+      expect(entityContent).toContain(
+        "@Column({ type: 'timestamp', nullable: false })"
+      );
+      expect(entityContent).toContain("occurredAt: Date;");
+      // datetime is an alias for a naive timestamp column
+      expect(entityContent).toContain(
+        "@Column({ type: 'timestamp', nullable: true })"
+      );
+      expect(entityContent).toContain("loggedAt: Date;");
+    });
   });
 });


### PR DESCRIPTION
Closes #74

## Problem
The only date-ish field type was `date` (date-only). There was no way to declare a precise instant (timestamp with time zone) as an ordinary nullable field.

## Fix
Exposed `timestamptz`, `timestamp`, and `datetime` as public field types. The column templates and most type-mappings already existed; the gap was registration/validation:
- Added the three types to the `FieldType` union (`src/lib/types/field.ts`).
- `src/lib/utils/field.ts`: `datetime` → `timestamp` in `fieldTypeToColumnType` and `normalizeFieldType` (alias); added `datetime` to `typeToJsType`.
- Added `timestamptz` to the MCP schema validator's valid-types list and updated the doctor field-type suggestion.

Generated output (nullable honored):
```ts
@Column({ type: 'timestamptz', nullable: true })
capturedAt: Date;
```
`datetime` normalizes to a `timestamp` column.

## Tests
Generator tests for `timestamptz`/`timestamp`/`datetime` (correct `@Column`, nullable honored) and a doctor field-type validation test.

Build ✅ · lint 0 errors ✅ · `jest` (165, excl. pre-existing pglite/migrate failure on base) ✅

> Note: the timestamp templates declare the TS field as `: Date` while `typeToJsType` returns `"string"` for DTOs — a pre-existing inconsistency left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)