### PR TITLE
fix: scope apso generate formatting to generated output only (#70)

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -87,6 +87,14 @@ export default class Generate extends BaseCommand {
 
     console.log(`[apso] Generating ${language} code for ${entities.length} entities...`);
 
+    if (entities.length === 0) {
+      console.log(
+        "[apso] No entities found in .apsorc — nothing to generate. Check that the file exists and defines an `entities` array."
+      );
+    }
+
+    let generatedFileCount = 0;
+
     const generatorConfig: GeneratorConfig = {
       language,
       rootFolder,
@@ -113,6 +121,7 @@ export default class Generate extends BaseCommand {
       // eslint-disable-next-line no-await-in-loop
       await createFile(fullPath, file.content);
     }
+    generatedFileCount += enumFiles.length;
 
     // Generate shared query utilities
     const queryUtilFiles = await generator.generateQueryUtils(entities, lowerCaseApiType);
@@ -121,6 +130,7 @@ export default class Generate extends BaseCommand {
       // eslint-disable-next-line no-await-in-loop
       await createFile(fullPath, file.content);
     }
+    generatedFileCount += queryUtilFiles.length;
 
     // Generate per-entity files
     for (const entity of entities) {
@@ -170,6 +180,7 @@ export default class Generate extends BaseCommand {
           const fullPath = path.join(autogenPath, file.path);
           // eslint-disable-next-line no-await-in-loop
           await createFile(fullPath, file.content);
+          generatedFileCount += 1;
         }
       }
 
@@ -186,6 +197,7 @@ export default class Generate extends BaseCommand {
       // eslint-disable-next-line no-await-in-loop
       await createFile(fullPath, file.content);
     }
+    generatedFileCount += guardFiles.length;
 
     // Generate index module
     const indexFiles = await generator.generateIndexModule(entities, lowerCaseApiType);
@@ -194,19 +206,23 @@ export default class Generate extends BaseCommand {
       // eslint-disable-next-line no-await-in-loop
       await createFile(fullPath, file.content);
     }
+    generatedFileCount += indexFiles.length;
 
-    // Format generated files (TypeScript only)
-    if (language === "typescript" && !skipFormat) {
+    // Format generated files (TypeScript only).
+    // Run prettier directly against the generated output directory so we never
+    // reformat hand-written code elsewhere in the project tree (the project's
+    // `npm run format` script targets a broad glob like `{src,test}/**/*.ts`).
+    if (language === "typescript" && !skipFormat && generatedFileCount > 0) {
       const formatStart = performance.now();
-      console.log("[apso] Formatting files...");
-      await this.runNpmCommand(
-        ["run", "format", "src/autogen/**/*.ts", "src/guards/**/*.ts"],
-        true
-      );
+      console.log("[apso] Formatting generated files...");
+      const formatGlob = path.join(autogenPath, "**", "*.ts");
+      await this.runCommand("npx", ["prettier", "--write", formatGlob], true);
       const formatTime = performance.now() - formatStart;
       console.log(`[apso] Finished formatting in ${formatTime.toFixed(2)} ms`);
     } else if (skipFormat) {
       console.log("[apso] Skipping formatting (--skip-format flag set)");
+    } else if (generatedFileCount === 0) {
+      console.log("[apso] Skipping formatting (no files were generated)");
     }
 
     const totalBuildTime = performance.now() - totalBuildStart;

--- a/src/lib/base-command.ts
+++ b/src/lib/base-command.ts
@@ -3,16 +3,20 @@ import { spawn } from "child_process";
 import os from "os";
 
 export default abstract class BaseCommand extends Command {
-  async runNpmCommand(args: string[], silent = false): Promise<void> {
+  async runCommand(
+    command: string,
+    args: string[],
+    silent = false
+  ): Promise<void> {
     return new Promise((resolve: any, reject) => {
       const isWindows = os.platform() === "win32";
-      const command = isWindows ? "npm.cmd" : "npm";
+      const resolvedCommand = isWindows ? `${command}.cmd` : command;
       const stdio = silent ? "ignore" : "inherit";
 
-      const cmdStr = `${command} ${args.join(" ")}`;
+      const cmdStr = `${resolvedCommand} ${args.join(" ")}`;
       this.log(`Running: ${cmdStr}`);
 
-      const child = spawn(command, args, {
+      const child = spawn(resolvedCommand, args, {
         stdio,
         shell: isWindows,
       });
@@ -29,5 +33,9 @@ export default abstract class BaseCommand extends Command {
         this.error(`Failed to run: ${cmdStr}`);
       });
     });
+  }
+
+  async runNpmCommand(args: string[], silent = false): Promise<void> {
+    return this.runCommand("npm", args, silent);
   }
 }


### PR DESCRIPTION
Closes #70

## Problem
`apso generate`'s format step delegated to the target project's `npm run format`, whose broad glob (e.g. `{src,test}/**/*.ts`) reformatted the **entire** project tree on every run — rewriting hand-written code that has nothing to do with code generation.

## Fix
- **base-command:** extract a generic `runCommand(command, args, silent)`; `runNpmCommand` now delegates to it.
- **generate:** format via `npx prettier --write <rootFolder>/autogen/**/*.ts`, scoped to the generated output dir (the stale `src/guards` glob was unnecessary — guards live under `autogen/`). Guard formatting on `generatedFileCount > 0`, and warn when `.apsorc` defines no entities.

## Verification
End-to-end against a throwaway project containing a deliberately mis-formatted hand-written file outside `autogen`:
- With entities → prettier targeted only `…/src/autogen/**/*.ts`; the hand-written file was byte-identical afterward (previously it would have been reformatted).
- Build ✅ · lint 0 errors ✅

> Note: this change was previously committed onto `feat/import-supabase-data` (PR #69); it has been moved here as a standalone PR and dropped from that branch so each lands independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)